### PR TITLE
Update to code.js

### DIFF
--- a/audit_tool/code.js
+++ b/audit_tool/code.js
@@ -212,13 +212,13 @@ function identifyVolatiles(sheet) {
   var queryCounter = 0;  
   var iferrorCounter = 0;
   var indirectCounter = 0;
-  var reNow = /.*NOW.*/;
-  var reToday = /.*TODAY.*/;
-  var reRand = /.*RAND.*/;
-  var reRandbetween = /.*RANDBETWEEN.*/;
-  var reQuery = /.*QUERY.*/;
-  var reIfError = /.*IFERROR.*/;
-  var reInDirect = /.*INDIRECT.*/;
+  var reNow = /.*NOW\(.*/;
+  var reToday = /.*TODAY\(.*/;
+  var reRand = /.*RAND\(.*/;
+  var reRandbetween = /.*RANDBETWEEN\(.*/;
+  var reQuery = /.*QUERY\(.*/;
+  var reIfError = /.*IFERROR\(.*/;
+  var reInDirect = /.*INDIRECT\(.*/;
   
   if (data_counter !== 0) {
   


### PR DESCRIPTION
Updating the REGEX to match the "(" of the volatile formula functions . This will fix an error I was seeing where the previous regex's were partially matching words (Like "Grand total" was counting as a RAND() function)